### PR TITLE
add tags to cluster resources, create databases if a list of names is passed

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,7 @@ resource "digitalocean_database_cluster" "do_redis" {
   region     = var.region
   node_count = var.node_count
   version    = var.db_version
+  tags       = var.tags
 
   eviction_policy = var.eviction_policy
   maintenance_window {
@@ -86,6 +87,7 @@ resource "digitalocean_database_cluster" "do_pg" {
   region     = var.region
   node_count = var.node_count
   version    = var.db_version
+  tags       = var.tags
 
   maintenance_window {
     day  = var.maintenance_window.day
@@ -103,6 +105,7 @@ resource "digitalocean_database_cluster" "do_mongodb" {
   region     = var.region
   node_count = var.node_count
   version    = var.db_version
+  tags       = var.tags
 
   maintenance_window {
     day  = var.maintenance_window.day
@@ -163,6 +166,34 @@ resource "digitalocean_database_firewall" "mongodb_firewall" {
       value = rule.value.value
     }
   }
+}
+
+resource "digitalocean_database_db" "sql_dbs" {
+  count = var.engine == "mysql" ? length(var.databases) : 0
+
+  cluster_id = digitalocean_database_cluster.do_sql[0].id
+  name       = var.databases[count.index]
+}
+
+resource "digitalocean_database_db" "redis_dbs" {
+  count = var.engine == "redis" ? length(var.databases) : 0
+
+  cluster_id = digitalocean_database_cluster.do_redis[0].id
+  name       = var.databases[count.index]
+}
+
+resource "digitalocean_database_db" "pg_dbs" {
+  count = var.engine == "pg" ? length(var.databases) : 0
+
+  cluster_id = digitalocean_database_cluster.do_pg[0].id
+  name       = var.databases[count.index]
+}
+
+resource "digitalocean_database_db" "mongodb_dbs" {
+  count = var.engine == "mongodb" ? length(var.databases) : 0
+
+  cluster_id = digitalocean_database_cluster.do_mongodb[0].id
+  name       = var.databases[count.index]
 }
 
 resource "digitalocean_database_user" "sql_users" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -46,16 +46,16 @@ output "password" {
 
 output "passwords" {
   description = "The generated passords for the created users as a key/value object"
-  sensitive = true
-  value     = local.passwords
+  sensitive   = true
+  value       = local.passwords
 }
 
 output "replicas" {
   description = "A list of created replia objects"
-  value = digitalocean_database_replica.pg_replicas
+  value       = digitalocean_database_replica.pg_replicas
 }
 
 output "pools" {
   description = "A list of created connetcion pool objects"
-  value = digitalocean_database_connection_pool.pg_pools
+  value       = digitalocean_database_connection_pool.pg_pools
 }

--- a/variables.tf
+++ b/variables.tf
@@ -60,6 +60,12 @@ variable "firewall_rules" {
   default     = []
 }
 
+variable "databases" {
+  type        = list(string)
+  description = "A list of database names to create in the cluster."
+  default     = []
+}
+
 variable "users" {
   description = "A list of database users to create"
   default     = []


### PR DESCRIPTION
@mohsenSy This PR will allow a user to pass a list of database names that will be created during the startup of the DO DB cluster.  Each element of the list will become a new database.  I allowed this to be passed for all DO DB cluster types.

This also accepts tags for database clusters to allow tags to be applied during cluster creation.

Finally I ran a terraform fmt and it formatted the outputs slightly.  I tested this with terraform 1.1

